### PR TITLE
Improve logging, use f-strings

### DIFF
--- a/tuyamqtt/__init__.py
+++ b/tuyamqtt/__init__.py
@@ -13,8 +13,11 @@ if True:
 else:
     # for local testing tuyaface
     import tuya.tuyaface as tuyaface
-# logging.basicConfig(level=logging.DEBUG)
     from tuya.tuyaface.tuyaclient import TuyaClient
+
+loglevel=logging.INFO
+loglevel=logging.DEBUG
+logging.basicConfig(format='%(asctime)s %(levelname)-8s (%(threadName)s) [%(name)s] %(message)s', level=loglevel)
 logger = logging.getLogger(__name__)
 
 
@@ -67,7 +70,7 @@ class TuyaMQTTEntity(Thread):
         self.entity = entity
         self.mqtt_topic = entity['topic']
 
-        self.mqtt_topic = "tuya/%s/%s/%s/%s"%(entity['protocol'],entity['deviceid'],entity['localkey'],entity['ip'])
+        self.mqtt_topic = f"tuya/{entity['protocol']}/{entity['deviceid']}/{entity['localkey']}/{entity['ip']}"
 
         self.parent = parent
         self.config = self.parent.config   
@@ -88,7 +91,7 @@ class TuyaMQTTEntity(Thread):
             self.mqtt_client.loop_start()   
             self.mqtt_client.on_message = self.on_message
         except Exception as ex:
-            logger.warning('Failed to connect to MQTT Broker %s' % ex)
+            logger.warning('(%s) Failed to connect to MQTT Broker %s', self.entity['ip'], ex)
             self.mqtt_connected = False
 
 
@@ -97,7 +100,7 @@ class TuyaMQTTEntity(Thread):
         if message.topic[-7:] != 'command':
             return   
 
-        logging.debug("topic %s retained %s message received %s" % (message.topic,message.retain,str(message.payload.decode("utf-8"))))
+        logging.debug("(%s) topic %s retained %s message received %s", self.entity['ip'], message.topic,message.retain,str(message.payload.decode("utf-8")))
 
         entityParts = message.topic.split("/")  
         dps_key = str(entityParts[5]) #will give problem with custom topics
@@ -136,7 +139,7 @@ class TuyaMQTTEntity(Thread):
             
             if dps_key not in self.entity['attributes']['dps']:
                 self._set_dps(dps_key, None)
-            logger.debug("_process_data %s : %s" % (dps_key, dps_value))
+            logger.debug("(%s) _process_data %s : %s", self.entity['ip'], dps_key, dps_value)
 
             if dps_key not in self.entity['attributes']['via']:
                 self._set_via(dps_key, 'init')
@@ -144,8 +147,8 @@ class TuyaMQTTEntity(Thread):
                 changed = True
                 self._set_dps(dps_key, dps_value) 
 
-                logger.debug("->publish %s/%s/state" % (self.mqtt_topic, dps_key))                
-                self.mqtt_client.publish("%s/%s/state" % (self.mqtt_topic, dps_key),  bool_payload(self.config, dps_value))  
+                logger.debug("(%s) ->publish %s/%s/state", self.entity['ip'], self.mqtt_topic, dps_key)
+                self.mqtt_client.publish(f"{self.mqtt_topic}/{dps_key}/state",  bool_payload(self.config, dps_value))
                 
                 if via != self.entity['attributes']['via'][dps_key]:                        
                     self._set_via(dps_key, via)
@@ -156,8 +159,8 @@ class TuyaMQTTEntity(Thread):
                     'time': time.time()
                 }
 
-                logger.debug("->publish %s/%s/attributes" % (self.mqtt_topic, dps_key)) 
-                self.mqtt_client.publish("%s/%s/attributes" % (self.mqtt_topic, dps_key),  json.dumps(attr_item))
+                logger.debug("(%s) ->publish %s/%s/attributes", self.entity['ip'], self.mqtt_topic, dps_key)
+                self.mqtt_client.publish(f"{self.mqtt_topic}/{dps_key}/attributes",  json.dumps(attr_item))
         
         if changed:
             attr = {
@@ -166,8 +169,8 @@ class TuyaMQTTEntity(Thread):
                 'time': time.time()
             } 
             
-            logger.debug("->publish %s/attributes" % (self.mqtt_topic))
-            self.mqtt_client.publish("%s/attributes" % (self.mqtt_topic),  json.dumps(attr))
+            logger.debug("(%s) ->publish %s/attributes", self.entity['ip'], (self.mqtt_topic))
+            self.mqtt_client.publish(f"{self.mqtt_topic}/attributes",  json.dumps(attr))
 
     def on_status(self, data:dict):
         self._process_data(data, 'tuya')
@@ -185,7 +188,7 @@ class TuyaMQTTEntity(Thread):
             self._set_availability(True)
 
         except Exception as ex:            
-            logger.error('status request on topic %s' % self.mqtt_topic, exc_info=False)
+            logger.exception('(%s) status request error', self.entity['ip'])
             self._set_availability(False)
 
 
@@ -201,7 +204,7 @@ class TuyaMQTTEntity(Thread):
             self._process_data(data, 'mqtt', True)
 
         except Exception as ex:
-            logger.error('set_state request on topic %s' % self.mqtt_topic, exc_info=True)
+            logger.error('(%s) set_state request on topic %s', self.entity['ip'], self.mqtt_topic, exc_info=True)
 
 
     def hass_discovery(self):
@@ -219,7 +222,7 @@ class TuyaMQTTEntity(Thread):
             "avty_t":"~availability",
             "pl_avail": self.config['General']['availability_online'],
             "pl_not_avail": self.config['General']['availability_offline'],
-            "uniq_id": '%s_%s' % (self.entity['deviceid'], dps),
+            "uniq_id": f"{self.entity['deviceid']}_{dps}",
             "device":{
                 "identifiers":[self.entity['deviceid']],
                 "connections":[["mac", "D8:F1:5B:8C:60:4F"]]
@@ -247,16 +250,16 @@ class TuyaMQTTEntity(Thread):
 
             if time.time() > time_run_availability:               
                 time_run_availability = time.time()+15   
-                logger.debug("->publish %s/availability" % self.mqtt_topic)     
-                self.mqtt_client.publish("%s/availability" % self.mqtt_topic, bool_availability(self.config, self.availability))         
+                logger.debug("(%s) ->publish %s/availability", self.entity['ip'], self.mqtt_topic)
+                self.mqtt_client.publish("{self.mqtt_topic}/availability", bool_availability(self.config, self.availability))
 
             time.sleep(self.delay)            
 
    
     def on_connect(self, client, userdata, flags, rc):
 
-        logger.info("MQTT Connection state: %s for %s" % (connack_string(rc), self.mqtt_topic))
-        client.subscribe("%s/#" % self.mqtt_topic)
+        logger.info("(%s) MQTT Connection state: %s for %s", self.entity['ip'], connack_string(rc), self.mqtt_topic)
+        client.subscribe(f"{self.mqtt_topic}/#")
         self.mqtt_connected = True
 
 
@@ -297,8 +300,8 @@ class TuyaMQTT:
 
     def on_connect(self, client, userdata, flags, rc):
 
-        logger.info("MQTT Connection state: %s for topic %s" % (connack_string(rc), self.mqtt_topic))
-        client.subscribe("%s/#" % self.mqtt_topic)
+        logger.info("MQTT Connection state: %s for topic %s",connack_string(rc), self.mqtt_topic)
+        client.subscribe("{self.mqtt_topic}/#")
         self.mqtt_connected = True
 
 
@@ -366,7 +369,7 @@ class TuyaMQTT:
         key = self.add_entity_dict(message.topic, message.retain)
 
         if key:
-            logger.info("message received %s topic %s retained %s " % (str(message.payload.decode("utf-8")),message.topic, message.retain)) 
+            logger.info("message received %s topic %s retained %s ", str(message.payload.decode("utf-8")), message.topic, message.retain)
             entity = self.get_entity(key)
             
             myThreadOb1 = TuyaMQTTEntity(key, entity, self)     

--- a/tuyamqtt/__init__.py
+++ b/tuyamqtt/__init__.py
@@ -16,7 +16,7 @@ else:
     from tuya.tuyaface.tuyaclient import TuyaClient
 
 loglevel=logging.INFO
-loglevel=logging.DEBUG
+#loglevel=logging.DEBUG
 logging.basicConfig(format='%(asctime)s %(levelname)-8s (%(threadName)s) [%(name)s] %(message)s', level=loglevel)
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
Improve logging to print IP of the device to make it possible to know which log is for which device.
Setup log format to include timestamp, thread and module name.
Use f-strings from python 3.6 instead of old school string formatting.